### PR TITLE
Fixed a compilation error in `dumptickets.nim` on nim < 2

### DIFF
--- a/dumptickets.nim
+++ b/dumptickets.nim
@@ -84,7 +84,7 @@ proc getLsaHandle(): HANDLE =
 
 proc getLogonSessionData(luid: LUID): ptr SECURITY_LOGON_SESSION_DATA = 
   var data: ptr SECURITY_LOGON_SESSION_DATA
-  let status = LsaGetLogonSessionData(addr luid, addr data)
+  let status = LsaGetLogonSessionData(unsafeAddr luid, addr data)
   if status != 0 or data == nil:
     return nil
   return data


### PR DESCRIPTION
Fixed compilation error in dumptickets.nim by replacing addr with unsafeAddr when passing the luid parameter to LsaGetLogonSessionData. This resolves the Nim compiler < 2 error:

Error: expression has no address; maybe use 'unsafeAddr'.